### PR TITLE
Fix precondition of `conditionalNegate()`

### DIFF
--- a/core/operations.h
+++ b/core/operations.h
@@ -134,8 +134,12 @@ namespace symfpu {
   bv conditionalNegate (const prop &p, const bv &b) {
     typename t::bwt w(b.getWidth());
     PRECONDITION(w >= 2);
-    PRECONDITION(IMPLIES(p, !(b.extract(w - 1, w - 1).isAllOnes() &&
-			      b.extract(w - 2,     0).isAllZeros())));
+    // We may be tempted to check that we are not trying to negate the smallest
+    // value that can be represented using two's complement (i.e., `100...0`).
+    // This is problematic, however, in cases where we apply
+    // `conditionalNegate()` conditionally (e.g., in `convertFloatToSBV()`),
+    // because the arguments to the branches are evaluated eagerly, so the
+    // assertion fails, even though the result is not used.
     
     return bv(ITE(p, -b, b));
   }


### PR DESCRIPTION
`conditionalNegate()` was asserting that if we negate the input, then
the input cannot correspond to `100...0`. However, this is problematic
when the operation is used conditionally. This is for example necessary
in `convertFloatToSBV()`, where we want to apply the negation if the
result is not the safe overflow value. This commit removes the assertion
and adds a comment to `conditionalNegate()` that documents why we cannot
have an assertion there.

Additionally, the commit makes `convertFloatToSBV()` safer by explicitly
handling the safe overflow case. Previously, we negated such a value,
even though it cannot be negated. This worked out in the cvc5 case
(because it blindly computes `~x + 1` without asserting anything), but
could be dangerous.