### PR TITLE
rounder: Fix invalid creation of zero-size bit-vector.

### DIFF
--- a/core/rounder.h
+++ b/core/rounder.h
@@ -223,8 +223,13 @@ namespace symfpu {
     ubv roundedSignificand(conditionalIncrement<t>(roundUp, extractedSignificand));
 
     ubv overflowBit(roundedSignificand.extract(targetWidth, targetWidth) & ubv(roundUp));
-    ubv carryUpMask((overflowBit | ubv(knownLeadingOne)).append(ubv::zero(targetWidth - 1)));   // Cheaper than conditional shift
-    
+    // Cheaper than conditional shift
+    ubv carryUpMask(overflowBit | ubv(knownLeadingOne));
+    if (targetWidth > 1)
+    {
+      carryUpMask = carryUpMask.append(ubv::zero(targetWidth - 1));
+    }
+
     // Build result
     significandRounderResult<t> result(roundedSignificand.extract(targetWidth-1,0) | carryUpMask,
 				    overflowBit.isAllOnes());


### PR DESCRIPTION
Fixes #8.

This fixes an issue where the rounder attempts to generate a bit-vector of size 0 in fixedPositionRound() when converting an FP to an unsigned BV of size 1.

This was tested for both Bitwuzla and cvc5 (against with/without patch and against Z3) on all `*FP*` benchmarks in SMT-LIB, and with Murxla.