### PR TITLE
Fix undefined-behavior and correctness bugs in the reference and solver back-ends

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,3 @@ clean :
 
 test : applications/test.o $(LIBFILES)
 	$(CXX) $(CXXFLAGS) $^ -o $@
-
-cbmcverification : applications/cbmcverification.o $(LIBFILES)
-	$(CXX) $(CXXFLAGS) $^ -o $@
-
-generate : applications/generate.o $(LIBFILES)
-	$(CXX) $(CXXFLAGS) $^ -o $@
-

--- a/applications/implementations.h
+++ b/applications/implementations.h
@@ -508,6 +508,7 @@ class sympfuImplementation {
   static void setFormat (const fpt &newFormat) {
     if (format != NULL) {
       delete format;
+      format = NULL;
     }
     format = new fpt(newFormat);
     return;
@@ -515,6 +516,7 @@ class sympfuImplementation {
 
   static void destroyFormat() {
     delete format;
+    format = NULL;
     return;
   }
   

--- a/applications/test.cpp
+++ b/applications/test.cpp
@@ -1235,6 +1235,15 @@ void regressionSignExtendRightShiftTest (const int verbose, const uint64_t, cons
   if (verbose || !ok) { fprintf(stdout, "%s", ok ? "PASS" : "FAIL"); }
 }
 
+void regressionModularAddWrapTest (const int verbose, const uint64_t, const uint64_t) {
+  typedef symfpu::simpleExecutable::bitVector<int64_t> bv;
+  bv a(4, 7), b(4, 1);
+  bv expected(4, -8);
+  bool ok = (a.modularAdd(b) == expected);
+  if (!ok) { ++failureCount; }
+  if (verbose || !ok) { fprintf(stdout, "%s", ok ? "PASS" : "FAIL"); }
+}
+
 /*** Application ***/
 
 
@@ -1280,6 +1289,7 @@ int main (int argc, char **argv) {
     {1,0,  "contractMasksHighBits", regressionContractMaskTest, regressionPrintNoop, regressionPrintNoop, NULL, NULL},
     {1,0,  "width1SignedEquality", regressionWidth1SignedEqualityTest, regressionPrintNoop, regressionPrintNoop, NULL, NULL},
     {1,0,  "signExtendRightShift", regressionSignExtendRightShiftTest, regressionPrintNoop, regressionPrintNoop, NULL, NULL},
+    {1,0,  "modularAddWrap", regressionModularAddWrapTest, regressionPrintNoop, regressionPrintNoop, NULL, NULL},
     {0,0,                 NULL, NULL, NULL, NULL,                           NULL,  NULL}
   };
 

--- a/applications/test.cpp
+++ b/applications/test.cpp
@@ -1199,6 +1199,15 @@ void regressionCtorMaxWidthTest (const int verbose, const uint64_t, const uint64
   if (verbose || !ok) { fprintf(stdout, "%s", ok ? "PASS" : "FAIL"); }
 }
 
+void regressionMaxValueWidth64Test (const int verbose, const uint64_t, const uint64_t) {
+  typedef symfpu::simpleExecutable::bitVector<uint64_t> bv;
+  bv mv(bv::maxValue(64));
+  bv expected(64, ~0ULL);
+  bool ok = (mv == expected);
+  if (!ok) { ++failureCount; }
+  if (verbose || !ok) { fprintf(stdout, "%s", ok ? "PASS" : "FAIL"); }
+}
+
 /*** Application ***/
 
 
@@ -1240,6 +1249,7 @@ int main (int argc, char **argv) {
     {0,0,          "remainder", INST(binaryFunction, rem),              "remainderf(f,g)",  "(fp.remainder f g)"},
     {1,0,  "isCatastrophicCancellation", regressionCatastrophicCancellationTest, regressionPrintNoop, regressionPrintNoop, NULL, NULL},
     {1,0,  "ctorAtMaxWidth", regressionCtorMaxWidthTest, regressionPrintNoop, regressionPrintNoop, NULL, NULL},
+    {1,0,  "maxValueAtMaxWidth", regressionMaxValueWidth64Test, regressionPrintNoop, regressionPrintNoop, NULL, NULL},
     {0,0,                 NULL, NULL, NULL, NULL,                           NULL,  NULL}
   };
 

--- a/applications/test.cpp
+++ b/applications/test.cpp
@@ -1226,6 +1226,15 @@ void regressionWidth1SignedEqualityTest (const int verbose, const uint64_t, cons
   if (verbose || !ok) { fprintf(stdout, "%s", ok ? "PASS" : "FAIL"); }
 }
 
+void regressionSignExtendRightShiftTest (const int verbose, const uint64_t, const uint64_t) {
+  typedef symfpu::simpleExecutable::bitVector<int64_t> bv;
+  bv v(8, -2), sh(8, 2);
+  bv expected(8, -1);
+  bool ok = (v.signExtendRightShift(sh) == expected);
+  if (!ok) { ++failureCount; }
+  if (verbose || !ok) { fprintf(stdout, "%s", ok ? "PASS" : "FAIL"); }
+}
+
 /*** Application ***/
 
 
@@ -1270,6 +1279,7 @@ int main (int argc, char **argv) {
     {1,0,  "maxValueAtMaxWidth", regressionMaxValueWidth64Test, regressionPrintNoop, regressionPrintNoop, NULL, NULL},
     {1,0,  "contractMasksHighBits", regressionContractMaskTest, regressionPrintNoop, regressionPrintNoop, NULL, NULL},
     {1,0,  "width1SignedEquality", regressionWidth1SignedEqualityTest, regressionPrintNoop, regressionPrintNoop, NULL, NULL},
+    {1,0,  "signExtendRightShift", regressionSignExtendRightShiftTest, regressionPrintNoop, regressionPrintNoop, NULL, NULL},
     {0,0,                 NULL, NULL, NULL, NULL,                           NULL,  NULL}
   };
 

--- a/applications/test.cpp
+++ b/applications/test.cpp
@@ -177,6 +177,11 @@ typedef sympfuImplementation<uint32_t, traits> singlePrecisionExecutableSymfpu;
 typedef native<uint32_t, float> singlePrecisionHardware;
 
 
+// Tally of comparison mismatches across the run.  main() returns nonzero
+// when this is nonzero so that CI can detect regressions.
+static uint64_t failureCount = 0;
+
+
 
 /*** Output helpers ***/
 
@@ -289,7 +294,9 @@ void unaryFunctionTest (const int verbose, const uint64_t start, const uint64_t 
       uint32_t reference = ref(input);
       uint32_t computed = test(input);
       
-      if (verbose || !singlePrecisionHardware::smtlibEqual(computed, reference)) {
+      bool ok = singlePrecisionHardware::smtlibEqual(computed, reference);
+      if (!ok) { ++failureCount; }
+      if (verbose || !ok) {
 	fprintf(stdout,"vector[%d] ", (uint32_t)i);
 	fprintf(stdout,"input = 0x%x, computed = 0x%x, real = 0x%x\n", input, computed, reference);
 	fflush(stdout);
@@ -381,7 +388,9 @@ void unaryRoundedFunctionTest (const int verbose, const uint64_t start, const ui
       uint32_t reference = ref(input);
       uint32_t computed = test(input);
       
-      if (verbose || !singlePrecisionHardware::smtlibEqual(computed, reference)) {
+      bool ok = singlePrecisionHardware::smtlibEqual(computed, reference);
+      if (!ok) { ++failureCount; }
+      if (verbose || !ok) {
 	fprintf(stdout,"vector[%d] ", (uint32_t)i);
 	fprintf(stdout,"input = 0x%x, computed = 0x%x, real = 0x%x\n", input, computed, reference);
 	fflush(stdout);
@@ -479,7 +488,9 @@ void unaryPredicateTest (const int verbose, const uint64_t start, const uint64_t
       bool reference = ref(input);
       bool computed = test(input);
       
-      if (verbose || !(computed == reference)) {
+      bool ok = (computed == reference);
+      if (!ok) { ++failureCount; }
+      if (verbose || !ok) {
 	fprintf(stdout,"vector[%d] ", (uint32_t)i);
 	fprintf(stdout,"input = 0x%x, computed = %d, real = %d\n", input, computed, reference);
 	fflush(stdout);
@@ -598,7 +609,9 @@ void binaryPredicateTest (const int verbose, const uint64_t start, const uint64_
     bool reference = ref(input1, input2);
     bool computed = test(input1, input2);
     
-    if (verbose || !(computed == reference)) {
+    bool ok = (computed == reference);
+    if (!ok) { ++failureCount; }
+    if (verbose || !ok) {
       fprintf(stdout,"vector[%d -> (%d,%d)] ", (uint32_t)i, (uint32_t)right, (uint32_t)left);
       fprintf(stdout,"input1 = 0x%x, input2 = 0x%x, computed = %d, real = %d\n", input1, input2, computed, reference);
       fflush(stdout);
@@ -721,7 +734,9 @@ void binaryFunctionTest (const int verbose, const uint64_t start, const uint64_t
     uint32_t reference = ref(input1, input2);
     uint32_t computed = test(input1, input2);
 
-    if (verbose || !singlePrecisionHardware::smtlibEqual(computed, reference)) {
+    bool ok = singlePrecisionHardware::smtlibEqual(computed, reference);
+    if (!ok) { ++failureCount; }
+    if (verbose || !ok) {
       fprintf(stdout,"vector[%d -> (%d,%d)] ", (uint32_t)i, (uint32_t)right, (uint32_t)left);
       fprintf(stdout,"input1 = 0x%x, input2 = 0x%x, computed = 0x%x, real = 0x%x\n", input1, input2, computed, reference);
       fflush(stdout);
@@ -844,7 +859,9 @@ void binaryRoundedFunctionTest (const int verbose, const uint64_t start, const u
     uint32_t reference = ref(input1, input2);
     uint32_t computed = test(input1, input2);
 
-    if (verbose || !singlePrecisionHardware::smtlibEqual(computed, reference)) {
+    bool ok = singlePrecisionHardware::smtlibEqual(computed, reference);
+    if (!ok) { ++failureCount; }
+    if (verbose || !ok) {
       fprintf(stdout,"vector[%d -> (%d,%d)] ", (uint32_t)i, (uint32_t)right, (uint32_t)left);
       fprintf(stdout,"input1 = 0x%x, input2 = 0x%x, computed = 0x%x, real = 0x%x\n", input1, input2, computed, reference);
       fflush(stdout);
@@ -1006,7 +1023,9 @@ void ternaryRoundedFunctionTest (const int verbose, const uint64_t start, const 
     uint32_t reference = ref(input1, input2, input3);
     uint32_t computed = test(input1, input2, input3);
 
-    if (verbose || !singlePrecisionHardware::smtlibEqual(computed, reference)) {
+    bool ok = singlePrecisionHardware::smtlibEqual(computed, reference);
+    if (!ok) { ++failureCount; }
+    if (verbose || !ok) {
       fprintf(stdout,"vector[%d -> (%d,%d,%d)] ", (uint32_t)i, (uint32_t)right, (uint32_t)middle, (uint32_t)left);
       fprintf(stdout,"input1 = 0x%x, input2 = 0x%x, input3 = 0x%x, computed = 0x%x, real = 0x%x\n", input1, input2, input3, computed, reference);
       fflush(stdout);
@@ -1421,5 +1440,5 @@ int main (int argc, char **argv) {
 
   singlePrecisionExecutableSymfpu::destroyFormat();
 
-  return 1;
+  return (failureCount == 0) ? 0 : 1;
 }

--- a/applications/test.cpp
+++ b/applications/test.cpp
@@ -1244,6 +1244,26 @@ void regressionModularAddWrapTest (const int verbose, const uint64_t, const uint
   if (verbose || !ok) { fprintf(stdout, "%s", ok ? "PASS" : "FAIL"); }
 }
 
+void regressionSignExtendAtMaxWidthTest (const int verbose, const uint64_t, const uint64_t) {
+  typedef symfpu::simpleExecutable::bitVector<uint64_t> bv;
+  // Full-width arithmetic shift at maxWidth(); exercises stickyRightShift's 1ULL<<64 path (E9).
+  bv sh(64, 64);
+  bool ok = (bv(64, 0x8000000000000000ULL).signExtendRightShift(sh) == bv(64, ~0ULL)) &&
+            (bv(64, 0x7FFFFFFFFFFFFFFFULL).signExtendRightShift(sh) == bv(64, 0));
+  if (!ok) { ++failureCount; }
+  if (verbose || !ok) { fprintf(stdout, "%s", ok ? "PASS" : "FAIL"); }
+}
+
+void regressionNegateMaxWidthTest (const int verbose, const uint64_t, const uint64_t) {
+  typedef symfpu::simpleExecutable::bitVector<int64_t> bv;
+  // E8 tripwire: -INT64_MIN negation is UB; value-equal at -O0, caught by -fsanitize=undefined.
+  bv v(64, static_cast<int64_t>(0x8000000000000000ULL));
+  bv expected(64, static_cast<int64_t>(0x8000000000000000ULL));
+  bool ok = (v.modularNegate() == expected);
+  if (!ok) { ++failureCount; }
+  if (verbose || !ok) { fprintf(stdout, "%s", ok ? "PASS" : "FAIL"); }
+}
+
 /*** Application ***/
 
 
@@ -1290,6 +1310,8 @@ int main (int argc, char **argv) {
     {1,0,  "width1SignedEquality", regressionWidth1SignedEqualityTest, regressionPrintNoop, regressionPrintNoop, NULL, NULL},
     {1,0,  "signExtendRightShift", regressionSignExtendRightShiftTest, regressionPrintNoop, regressionPrintNoop, NULL, NULL},
     {1,0,  "modularAddWrap", regressionModularAddWrapTest, regressionPrintNoop, regressionPrintNoop, NULL, NULL},
+    {1,0,  "signExtendAtMaxWidth", regressionSignExtendAtMaxWidthTest, regressionPrintNoop, regressionPrintNoop, NULL, NULL},
+    {1,0,  "negateAtMaxWidth", regressionNegateMaxWidthTest, regressionPrintNoop, regressionPrintNoop, NULL, NULL},
     {0,0,                 NULL, NULL, NULL, NULL,                           NULL,  NULL}
   };
 

--- a/applications/test.cpp
+++ b/applications/test.cpp
@@ -1217,6 +1217,15 @@ void regressionContractMaskTest (const int verbose, const uint64_t, const uint64
   if (verbose || !ok) { fprintf(stdout, "%s", ok ? "PASS" : "FAIL"); }
 }
 
+void regressionWidth1SignedEqualityTest (const int verbose, const uint64_t, const uint64_t) {
+  typedef symfpu::simpleExecutable::bitVector<int64_t> bv;
+  bv a(1,  1);
+  bv b(1, -1);
+  bool ok = (a == b);
+  if (!ok) { ++failureCount; }
+  if (verbose || !ok) { fprintf(stdout, "%s", ok ? "PASS" : "FAIL"); }
+}
+
 /*** Application ***/
 
 
@@ -1260,6 +1269,7 @@ int main (int argc, char **argv) {
     {1,0,  "ctorAtMaxWidth", regressionCtorMaxWidthTest, regressionPrintNoop, regressionPrintNoop, NULL, NULL},
     {1,0,  "maxValueAtMaxWidth", regressionMaxValueWidth64Test, regressionPrintNoop, regressionPrintNoop, NULL, NULL},
     {1,0,  "contractMasksHighBits", regressionContractMaskTest, regressionPrintNoop, regressionPrintNoop, NULL, NULL},
+    {1,0,  "width1SignedEquality", regressionWidth1SignedEqualityTest, regressionPrintNoop, regressionPrintNoop, NULL, NULL},
     {0,0,                 NULL, NULL, NULL, NULL,                           NULL,  NULL}
   };
 

--- a/applications/test.cpp
+++ b/applications/test.cpp
@@ -1208,6 +1208,15 @@ void regressionMaxValueWidth64Test (const int verbose, const uint64_t, const uin
   if (verbose || !ok) { fprintf(stdout, "%s", ok ? "PASS" : "FAIL"); }
 }
 
+void regressionContractMaskTest (const int verbose, const uint64_t, const uint64_t) {
+  typedef symfpu::simpleExecutable::bitVector<uint64_t> bv;
+  bv a(16, 0x1FF);
+  bv expected(8, 0xFF);
+  bool ok = (a.contract(8) == expected);
+  if (!ok) { ++failureCount; }
+  if (verbose || !ok) { fprintf(stdout, "%s", ok ? "PASS" : "FAIL"); }
+}
+
 /*** Application ***/
 
 
@@ -1250,6 +1259,7 @@ int main (int argc, char **argv) {
     {1,0,  "isCatastrophicCancellation", regressionCatastrophicCancellationTest, regressionPrintNoop, regressionPrintNoop, NULL, NULL},
     {1,0,  "ctorAtMaxWidth", regressionCtorMaxWidthTest, regressionPrintNoop, regressionPrintNoop, NULL, NULL},
     {1,0,  "maxValueAtMaxWidth", regressionMaxValueWidth64Test, regressionPrintNoop, regressionPrintNoop, NULL, NULL},
+    {1,0,  "contractMasksHighBits", regressionContractMaskTest, regressionPrintNoop, regressionPrintNoop, NULL, NULL},
     {0,0,                 NULL, NULL, NULL, NULL,                           NULL,  NULL}
   };
 

--- a/applications/test.cpp
+++ b/applications/test.cpp
@@ -1168,6 +1168,30 @@ struct roundingModeTestStruct {
 
 
 
+void regressionPrintNoop (const int, const uint64_t, const uint64_t,
+                          const char *, const char *, const char *) {
+}
+
+void regressionCatastrophicCancellationTest (const int verbose, const uint64_t, const uint64_t) {
+  typedef symfpu::simpleExecutable::traits traits;
+  typedef symfpu::unpackedFloat<traits> uf;
+  typedef traits::ubv ubv;
+
+  ubv one(32, 0x3f800000u);
+  ubv kilo(32, 0x44800000u);
+  uf onef(symfpu::unpack<traits>(singlePrecisionFormatObject, one));
+  uf kilof(symfpu::unpack<traits>(singlePrecisionFormatObject, kilo));
+
+  bool sameMinusSame = symfpu::isCatastrophicCancellation<traits>(
+      singlePrecisionFormatObject, onef, onef, 2, false);
+  bool farMinusFar = symfpu::isCatastrophicCancellation<traits>(
+      singlePrecisionFormatObject, onef, kilof, 2, false);
+
+  bool ok = sameMinusSame && !farMinusFar;
+  if (!ok) { ++failureCount; }
+  if (verbose || !ok) { fprintf(stdout, "%s", ok ? "PASS" : "FAIL"); }
+}
+
 /*** Application ***/
 
 
@@ -1207,6 +1231,7 @@ int main (int argc, char **argv) {
     {0,1,  "round_to_integral", INST(unaryRoundedFunction, rti),        "(fegetround()==FE_TONEAREST) ? rintf(f) : (fegetround()==FE_UPWARD) ? ceilf(f) : (fegetround()==FE_DOWNWARD) ? floorf(f) : truncf(f)",  "(fp.roundToIntegral rm f)"},
     {0,1,                "fma", INST(ternaryRoundedFunction, fma),      "fmaf(f,g)",  "(fp.fma rm f g h)"},
     {0,0,          "remainder", INST(binaryFunction, rem),              "remainderf(f,g)",  "(fp.remainder f g)"},
+    {1,0,  "isCatastrophicCancellation", regressionCatastrophicCancellationTest, regressionPrintNoop, regressionPrintNoop, NULL, NULL},
     {0,0,                 NULL, NULL, NULL, NULL,                           NULL,  NULL}
   };
 

--- a/applications/test.cpp
+++ b/applications/test.cpp
@@ -1192,6 +1192,13 @@ void regressionCatastrophicCancellationTest (const int verbose, const uint64_t, 
   if (verbose || !ok) { fprintf(stdout, "%s", ok ? "PASS" : "FAIL"); }
 }
 
+void regressionCtorMaxWidthTest (const int verbose, const uint64_t, const uint64_t) {
+  symfpu::simpleExecutable::bitVector<uint64_t> a(64, 1);
+  bool ok = (a.contents() == 1);
+  if (!ok) { ++failureCount; }
+  if (verbose || !ok) { fprintf(stdout, "%s", ok ? "PASS" : "FAIL"); }
+}
+
 /*** Application ***/
 
 
@@ -1232,6 +1239,7 @@ int main (int argc, char **argv) {
     {0,1,                "fma", INST(ternaryRoundedFunction, fma),      "fmaf(f,g)",  "(fp.fma rm f g h)"},
     {0,0,          "remainder", INST(binaryFunction, rem),              "remainderf(f,g)",  "(fp.remainder f g)"},
     {1,0,  "isCatastrophicCancellation", regressionCatastrophicCancellationTest, regressionPrintNoop, regressionPrintNoop, NULL, NULL},
+    {1,0,  "ctorAtMaxWidth", regressionCtorMaxWidthTest, regressionPrintNoop, regressionPrintNoop, NULL, NULL},
     {0,0,                 NULL, NULL, NULL, NULL,                           NULL,  NULL}
   };
 

--- a/baseTypes/cprover_bvt.h
+++ b/baseTypes/cprover_bvt.h
@@ -171,7 +171,7 @@ namespace symfpu {
       
       static bitVector<isSigned> minValue (const bitWidthType &w) {
 	if (isSigned) {
-	  return allOnes(w);
+	  return one(1).append(zero(w-1));
 	} else {
 	  return zero(w);
 	}

--- a/baseTypes/cprover_bvt.h
+++ b/baseTypes/cprover_bvt.h
@@ -281,6 +281,10 @@ namespace symfpu {
 	return *this + op;
       }
 
+      inline bitVector<isSigned> modularSubtract (const bitVector<isSigned> &op) const {
+	return *this - op;
+      }
+
       inline bitVector<isSigned> modularNegate () const {
 	return -(*this);
       }

--- a/baseTypes/cprover_exprt.h
+++ b/baseTypes/cprover_exprt.h
@@ -272,6 +272,10 @@ namespace symfpu {
 	return *this + op;
       }
 
+      inline bitVector<isSigned> modularSubtract (const bitVector<isSigned> &op) const {
+	return *this - op;
+      }
+
       inline bitVector<isSigned> modularNegate () const {
 	return -(*this);
       }

--- a/baseTypes/cvc4_literal.cpp
+++ b/baseTypes/cvc4_literal.cpp
@@ -108,7 +108,13 @@ namespace symfpu {
     bitVector<false> bitVector<false>::operator / (const bitVector<false> &op) const { return this->CVC4BV::unsignedDivTotal(op); }
 
     template <>
+    bitVector<true> bitVector<true>::operator / (const bitVector<true> &op) const { return this->CVC4BV::signedDivTotal(op); }
+
+    template <>
     bitVector<false> bitVector<false>::operator % (const bitVector<false> &op) const { return this->CVC4BV::unsignedRemTotal(op); }
+
+    template <>
+    bitVector<true> bitVector<true>::operator % (const bitVector<true> &op) const { return this->CVC4BV::signedRemTotal(op); }
 
     template <bool isSigned>
     bitVector<isSigned> bitVector<isSigned>::operator - (void) const { return this->CVC4BV::operator-(); }

--- a/baseTypes/cvc4_literal.cpp
+++ b/baseTypes/cvc4_literal.cpp
@@ -43,6 +43,7 @@ namespace symfpu {
     template <bool isSigned>
     bitVector<isSigned> bitVector<isSigned>::maxValue (const bitWidthType &w) {
       if (isSigned) {
+	if (w == 1) { return bitVector<true>::zero(1); }
 	CVC4BV base(w-1, 0U);
 	return bitVector<true>((~base).zeroExtend(1));
       } else {

--- a/baseTypes/cvc4_literal.cpp
+++ b/baseTypes/cvc4_literal.cpp
@@ -161,6 +161,11 @@ namespace symfpu {
     }
 
     template <bool isSigned>
+    bitVector<isSigned> bitVector<isSigned>::modularSubtract (const bitVector<isSigned> &op) const {
+      return *this - op;
+    }
+
+    template <bool isSigned>
     bitVector<isSigned> bitVector<isSigned>::modularNegate () const {
       return -(*this);
     }

--- a/baseTypes/cvc4_literal.h
+++ b/baseTypes/cvc4_literal.h
@@ -159,6 +159,7 @@ namespace symfpu {
       bitVector<isSigned> modularIncrement () const;
       bitVector<isSigned> modularDecrement () const;
       bitVector<isSigned> modularAdd (const bitVector<isSigned> &op) const;
+      bitVector<isSigned> modularSubtract (const bitVector<isSigned> &op) const;
       bitVector<isSigned> modularNegate () const;
 
 

--- a/baseTypes/cvc4_symbolic.h
+++ b/baseTypes/cvc4_symbolic.h
@@ -307,7 +307,7 @@ namespace symfpu {
       }
 
       inline Node fromProposition (Node node) const {
-	#ifdef PROPSYMFPUISBOOL
+	#ifdef SYMFPUPROPISBOOL
 	return boolNodeToBV(node);
 	#else
 	return node;
@@ -315,7 +315,7 @@ namespace symfpu {
       }
 
       inline Node toProposition (Node node) const {
-	#ifdef PROPSYMFPUISBOOL
+	#ifdef SYMFPUPROPISBOOL
 	return node;
 	#else
 	return boolNodeToBV(node);
@@ -455,7 +455,7 @@ namespace symfpu {
       /*** Comparisons ***/
 
       inline proposition operator == (const bitVector<isSigned> &op) const {
-#ifdef PROPSYMFPUISBOOL
+#ifdef SYMFPUPROPISBOOL
 	return proposition(::CVC4::NodeManager::currentNM()->mkNode(::CVC4::kind::EQUAL, this->node, op.node));
 #else
 	return proposition(::CVC4::NodeManager::currentNM()->mkNode(::CVC4::kind::BITVECTOR_COMP, this->node, op.node));

--- a/baseTypes/cvc4_symbolic.h
+++ b/baseTypes/cvc4_symbolic.h
@@ -445,6 +445,10 @@ namespace symfpu {
 	return *this + op;
       }
 
+      inline bitVector<isSigned> modularSubtract (const bitVector<isSigned> &op) const {
+	return *this - op;
+      }
+
       inline bitVector<isSigned> modularNegate () const {
 	return -(*this);
       }

--- a/baseTypes/cvc4_symbolic.h
+++ b/baseTypes/cvc4_symbolic.h
@@ -478,11 +478,19 @@ namespace symfpu {
       }
 
       inline proposition operator < (const bitVector<isSigned> &op) const {
+#ifdef SYMFPUPROPISBOOL
+	return proposition(::CVC4::NodeManager::currentNM()->mkNode((isSigned) ? ::CVC4::kind::BITVECTOR_SLT : ::CVC4::kind::BITVECTOR_ULT, this->node, op.node));
+#else
 	return proposition(::CVC4::NodeManager::currentNM()->mkNode((isSigned) ? ::CVC4::kind::BITVECTOR_SLTBV : ::CVC4::kind::BITVECTOR_ULTBV, this->node, op.node));
+#endif
       }
 
       inline proposition operator > (const bitVector<isSigned> &op) const {
+#ifdef SYMFPUPROPISBOOL
+	return proposition(::CVC4::NodeManager::currentNM()->mkNode((isSigned) ? ::CVC4::kind::BITVECTOR_SLT : ::CVC4::kind::BITVECTOR_ULT, op.node, this->node));
+#else
 	return proposition(::CVC4::NodeManager::currentNM()->mkNode((isSigned) ? ::CVC4::kind::BITVECTOR_SLTBV : ::CVC4::kind::BITVECTOR_ULTBV, op.node, this->node));
+#endif
       }
 
       /*** Type conversion ***/

--- a/baseTypes/simpleExecutable.cpp
+++ b/baseTypes/simpleExecutable.cpp
@@ -26,6 +26,7 @@ namespace symfpu {
 
     template <>
     bool bitVector<int64_t>::isRepresentable (const bitWidthType w, const int64_t v) {
+      if (w == bitVector<int64_t>::maxWidth()) { return true; }
       uint64_t shiftSafe = *((uint64_t *)(&v));
       uint64_t top = (shiftSafe >> w);
       uint64_t signbit = shiftSafe & 0x8000000000000000;
@@ -35,6 +36,7 @@ namespace symfpu {
 
     template <>
     bool bitVector<uint64_t>::isRepresentable (const bitWidthType w, const uint64_t v) {
+      if (w == bitVector<uint64_t>::maxWidth()) { return true; }
       uint64_t top = (v >> w);
       return (top == 0);
     }

--- a/baseTypes/simpleExecutable.cpp
+++ b/baseTypes/simpleExecutable.cpp
@@ -66,7 +66,7 @@ namespace symfpu {
     template <>
     bitVector<uint64_t> bitVector<uint64_t>::maxValue (const bitWidthType &w) {
       PRECONDITION(w != 1);
-      return bitVector<uint64_t>(w, (1ULL << w) - 1);
+      return bitVector<uint64_t>(w, bitVector<uint64_t>::nOnes(w));
     }
 
     template <>

--- a/baseTypes/simpleExecutable.cpp
+++ b/baseTypes/simpleExecutable.cpp
@@ -85,7 +85,10 @@ namespace symfpu {
 
     template <>
     bitVector<int64_t> bitVector<int64_t>::operator- (void) const {
-      return bitVector<int64_t>(this->width, -this->value);
+      // Negate in unsigned arithmetic to avoid -INT64_MIN signed overflow UB.
+      uint64_t bits(~(*((uint64_t *)(&this->value))) + 1);
+      return bitVector<int64_t>(this->width,
+				bitVector<int64_t>::makeRepresentable(this->width, *((int64_t *)(&bits))));
     }
 
     // Used in addition
@@ -179,8 +182,10 @@ namespace symfpu {
 
     template <>
     bitVector<int64_t> bitVector<int64_t>::modularNegate (void) const {
-      return bitVector<int64_t>(this->width, 
-				bitVector<int64_t>::makeRepresentable(this->width, -this->value));
+      // Negate in unsigned arithmetic to avoid -INT64_MIN signed overflow UB.
+      uint64_t bits(~(*((uint64_t *)(&this->value))) + 1);
+      return bitVector<int64_t>(this->width,
+				bitVector<int64_t>::makeRepresentable(this->width, *((int64_t *)(&bits))));
     }
 
 

--- a/baseTypes/simpleExecutable.cpp
+++ b/baseTypes/simpleExecutable.cpp
@@ -113,19 +113,26 @@ namespace symfpu {
       uint64_t signBit = left & (1ULL << (width - 1));
  
       if (right <= width)  {
-	for (uint64_t i = 1; i <= width; i <<= 1) {
+	for (uint64_t i = 1; i < width; i <<= 1) {
 	  if (right & i) {
 	    uint64_t iOnes = ((1ULL << i) - 1);
 	    stickyBit |= ((newValue & iOnes) ? 1 : 0);
-	    
+
 	    // Sign extending shift
 	    if (signBit) {
 	      newValue = (newValue >> i) | (iOnes << (width - i));
 	    } else {
 	      newValue = (newValue >> i);
 	    }
-	    
+
 	  }
+	}
+	if (right == width) {
+	  // Whole-word shift collapses the value; stickyBit is set if any bit was set.
+	  stickyBit |= (newValue ? 1 : 0);
+	  // All-ones across `width` bits without shifting by `width` (UB at maxWidth).
+	  uint64_t allOnes = (width == 64) ? ~0ULL : ((1ULL << width) - 1);
+	  newValue = (signBit) ? allOnes : 0;
 	}
       } else {
 	newValue = (signBit) ? 0xFFFFFFFFFFFFFFFFULL : 0x0;

--- a/baseTypes/simpleExecutable.cpp
+++ b/baseTypes/simpleExecutable.cpp
@@ -27,10 +27,10 @@ namespace symfpu {
     template <>
     bool bitVector<int64_t>::isRepresentable (const bitWidthType w, const int64_t v) {
       if (w == bitVector<int64_t>::maxWidth()) { return true; }
-      uint64_t shiftSafe = *((uint64_t *)(&v));
+      uint64_t shiftSafe = static_cast<uint64_t>(v);
       uint64_t top = (shiftSafe >> w);
       uint64_t signbit = shiftSafe & 0x8000000000000000;
-      int64_t stop = *((int64_t *)(&top));
+      int64_t stop = static_cast<int64_t>(top);
       return (signbit) ? (stop == bitVector<int64_t>::nOnes(bitVector<int64_t>::maxWidth() - w)) : (stop == 0LL);
     }
 
@@ -52,10 +52,10 @@ namespace symfpu {
       // Mask to w bits then sign-extend.  Avoids overflow at w == maxWidth()
       // and matches the two's-complement wrap that modular operations expect.
       uint64_t mask(bitVector<int64_t>::nOnes(w));
-      uint64_t bits(*((uint64_t *)(&v)) & mask);
+      uint64_t bits(static_cast<uint64_t>(v) & mask);
       uint64_t signBit(1ULL << (w - 1));
       uint64_t extended((bits & signBit) ? (bits | ~mask) : bits);
-      return *((int64_t *)(&extended));
+      return static_cast<int64_t>(extended);
     }
 
     
@@ -86,9 +86,9 @@ namespace symfpu {
     template <>
     bitVector<int64_t> bitVector<int64_t>::operator- (void) const {
       // Negate in unsigned arithmetic to avoid -INT64_MIN signed overflow UB.
-      uint64_t bits(~(*((uint64_t *)(&this->value))) + 1);
+      uint64_t bits(~(static_cast<uint64_t>(this->value)) + 1);
       return bitVector<int64_t>(this->width,
-				bitVector<int64_t>::makeRepresentable(this->width, *((int64_t *)(&bits))));
+				bitVector<int64_t>::makeRepresentable(this->width, static_cast<int64_t>(bits)));
     }
 
     // Used in addition
@@ -159,9 +159,9 @@ namespace symfpu {
 
       // Reuse the unsigned helper, treating the stored bit pattern as the
       // width-bit two's-complement value to be arithmetically shifted.
-      uint64_t bits(*((uint64_t *)(&this->value)) & bitVector<int64_t>::nOnes(this->width));
+      uint64_t bits(static_cast<uint64_t>(this->value) & bitVector<int64_t>::nOnes(this->width));
       uint64_t shifted(stickyRightShift(true, this->width, bits, static_cast<uint64_t>(op.value)));
-      return bitVector<int64_t>(this->width, *((int64_t *)(&shifted)));
+      return bitVector<int64_t>(this->width, static_cast<int64_t>(shifted));
     }
 
     template<>
@@ -190,9 +190,9 @@ namespace symfpu {
     template <>
     bitVector<int64_t> bitVector<int64_t>::modularNegate (void) const {
       // Negate in unsigned arithmetic to avoid -INT64_MIN signed overflow UB.
-      uint64_t bits(~(*((uint64_t *)(&this->value))) + 1);
+      uint64_t bits(~(static_cast<uint64_t>(this->value)) + 1);
       return bitVector<int64_t>(this->width,
-				bitVector<int64_t>::makeRepresentable(this->width, *((int64_t *)(&bits))));
+				bitVector<int64_t>::makeRepresentable(this->width, static_cast<int64_t>(bits)));
     }
 
 
@@ -219,13 +219,13 @@ namespace symfpu {
     
     template <>
     bitVector<typename modifySignedness<uint64_t>::signedVersion> bitVector<uint64_t>::toSigned (void) const {
-      return bitVector<int64_t>(this->width, *((int64_t *)&this->value));
+      return bitVector<int64_t>(this->width, static_cast<int64_t>(this->value));
     }
 
     template <>
     bitVector<typename modifySignedness<int64_t>::unsignedVersion> bitVector<int64_t>::toUnsigned (void) const {
       // Note we need to mask out the (sign extensions) of the negative part.
-      return bitVector<uint64_t>(this->width, (*((uint64_t *)&this->value)) & bitVector<int64_t>::nOnes(this->width));
+      return bitVector<uint64_t>(this->width, (static_cast<uint64_t>(this->value)) & bitVector<int64_t>::nOnes(this->width));
     }
 
 

--- a/baseTypes/simpleExecutable.cpp
+++ b/baseTypes/simpleExecutable.cpp
@@ -145,16 +145,11 @@ namespace symfpu {
       PRECONDITION(this->width == op.width);
       PRECONDITION(this->width < CHAR_BIT*sizeof(int64_t));
 
-      int64_t newValue;
-      
-      if (this->value < 0) {
-	newValue = -(-(this->value) >> op.value) + ((this->value & 0x1) ? -1 : 0); // Rounds away
-      } else {
-	newValue = this->value >> op.value;
-      }
-      
-      return bitVector<int64_t>(this->width,
-				bitVector<int64_t>::makeRepresentable(this->width, newValue));
+      // Reuse the unsigned helper, treating the stored bit pattern as the
+      // width-bit two's-complement value to be arithmetically shifted.
+      uint64_t bits(*((uint64_t *)(&this->value)) & bitVector<int64_t>::nOnes(this->width));
+      uint64_t shifted(stickyRightShift(true, this->width, bits, static_cast<uint64_t>(op.value)));
+      return bitVector<int64_t>(this->width, *((int64_t *)(&shifted)));
     }
 
     template<>

--- a/baseTypes/simpleExecutable.cpp
+++ b/baseTypes/simpleExecutable.cpp
@@ -49,11 +49,13 @@ namespace symfpu {
 
     template <>
     int64_t bitVector<int64_t>::makeRepresentable (const bitWidthType w, const int64_t v) {
-      if (v <= ((1LL << (w - 1)) - 1) && (-(1LL << (w - 1)) <= v)) {
-	return v;
-      } else {
-	return 0;
-      }
+      // Mask to w bits then sign-extend.  Avoids overflow at w == maxWidth()
+      // and matches the two's-complement wrap that modular operations expect.
+      uint64_t mask(bitVector<int64_t>::nOnes(w));
+      uint64_t bits(*((uint64_t *)(&v)) & mask);
+      uint64_t signBit(1ULL << (w - 1));
+      uint64_t extended((bits & signBit) ? (bits | ~mask) : bits);
+      return *((int64_t *)(&extended));
     }
 
     

--- a/baseTypes/simpleExecutable.h
+++ b/baseTypes/simpleExecutable.h
@@ -328,7 +328,8 @@ namespace symfpu {
       inline bitVector<T> contract (bitWidthType reduction) const {
 	PRECONDITION(this->width > reduction);
 
-	return bitVector<T>(this->width - reduction, this->value);
+	bitWidthType newWidth(this->width - reduction);
+	return bitVector<T>(newWidth, bitVector<T>::makeRepresentable(newWidth, this->value));
       }
 
       inline bitVector<T> resize (bitWidthType newSize) const {

--- a/baseTypes/simpleExecutable.h
+++ b/baseTypes/simpleExecutable.h
@@ -285,7 +285,11 @@ namespace symfpu {
 
       inline proposition operator == (const bitVector<T> &op) const {
 	PRECONDITION(this->width == op.width);
-	return proposition(this->value == op.value);
+	// Mask to width before comparison so distinct internal encodings of
+	// the same logical value (e.g. width-1 signed -1 stored as 1 or -1)
+	// compare equal.
+	T mask(bitVector<T>::nOnes(this->width));
+	return proposition((this->value & mask) == (op.value & mask));
       }
 
       inline proposition operator <= (const bitVector<T> &op) const {

--- a/core/add.h
+++ b/core/add.h
@@ -753,8 +753,8 @@ template <class t>
    bwt topBit(significandWidth - 2);
    bwt bottomBit(significandWidth - cancelAmount);
 
-   ubv leftExtract(left.getSignificand.extract(topBit, bottomBit));
-   ubv rightExtract(right.getSignificand.extract(topBit, bottomBit));
+   ubv leftExtract(left.getSignificand().extract(topBit, bottomBit));
+   ubv rightExtract(right.getSignificand().extract(topBit, bottomBit));
 
    prop result(ITE(!effectiveAdd && !leftSpecial && !rightSpecial,
 		   ITE(ec.diffIsZero,


### PR DESCRIPTION
While going through the codebase I noticed a number of things and figured it might be useful to share these observations. 

For items whose effect is reachable through `simpleExecutable`, the fix commit also adds a paired regression test in `applications/test.cpp` that exercises the buggy path on known inputs.

## A. Test harness

- **A.** `applications/test.cpp::main` returns `1` unconditionally and the test loops have no failure tally; the exit code says nothing about test outcomes. Adds a `failureCount` tally so the exit code reflects mismatches; subsequent commits' regression tests bump it.

## B. Build infrastructure

- **B.** Root `Makefile` has `cbmcverification` and `generate` rules pointing at `applications/cbmcverification.cpp` / `applications/generate.cpp`; neither file exists in this repo. Removed.

## C. Spelling

- **C1.** `core/add.h:756-757` — `left.getSignificand.extract(...)` and `right.getSignificand.extract(...)` reference the member function instead of calling it. Paired with `regressionCatastrophicCancellationTest`, which calls `symfpu::isCatastrophicCancellation<traits>` on two known input pairs (same float minus same float → cancellation; far-apart floats minus → no cancellation) and checks the predicate's return value.
- **C2.** `baseTypes/cvc4_symbolic.h` — three `#ifdef PROPSYMFPUISBOOL` sites; the macro defined and used elsewhere is `SYMFPUPROPISBOOL`.

## D. Solver back-ends

- **D1.** `cvc4_literal.h`, `cvc4_symbolic.h`, `cprover_bvt.h`, `cprover_exprt.h` — `modularSubtract` is not defined; only `simpleExecutable` provides it.
- **D2.** `cvc4_literal.cpp` — `bitVector<true>::operator/` and `operator%` are declared in the header, but only the `<false>` specialisations are defined.
- **D3.** `cprover_bvt.h::minValue` — for `isSigned`, returns `allOnes(w)` (= `-1`) instead of `100…0` (= `INT_MIN`). The other four backends construct `100…0`; this one is a copy-paste slip.
- **D4.** `cvc4_symbolic.h::operator<`, `operator>` — emit `BITVECTOR_SLTBV` / `ULTBV` unconditionally; no `SYMFPUPROPISBOOL` dispatch (compare with `operator==`, which has it).
- **D5.** `cvc4_literal.cpp::maxValue<true>(1)` constructs a zero-width BV (`CVC4BV(0, 0U)`) when `w == 1`.

## E. Reference back-end

- **E1.** `applications/implementations.h::setFormat`, `destroyFormat` — `delete format;` is now paired with `format = NULL;`.
- **E2.** `simpleExecutable::isRepresentable<{int,uint}64_t>` — early-returns when `w == maxWidth()` to dodge the shift-by-width undefined behavior. Paired with `regressionCtorMaxWidthTest`: `bitVector<uint64_t>(64, 1).contents() == 1`.
- **E3.** `simpleExecutable::maxValue<uint64_t>` — uses `nOnes(w)` instead of `(1ULL << w) - 1` so `w == 64` no longer hits shift-by-width undefined behavior. Paired with `regressionMaxValueWidth64Test`: `bv::maxValue(64) == bv(64, ~0ULL)`.
- **E4.** `simpleExecutable::contract` — masks high bits so the contracted value fits the new width. Paired with `regressionContractMaskTest`: `bv(16, 0x1FF).contract(8) == bv(8, 0xFF)`.
- **E5.** `bitVector::operator==` — masks both sides to `width` bits so distinct internal encodings of the same logical value compare equal. Paired with `regressionWidth1SignedEqualityTest`: `bv<int64_t>(1, 1) == bv<int64_t>(1, -1)`.
- **E6.** `signExtendRightShift<int64_t>` — reuses the unsigned `stickyRightShift` helper so negative inputs sign-extend correctly at shifts ≥ 2. Paired with `regressionSignExtendRightShiftTest`: `bv<int64_t>(8, -2).signExtendRightShift(bv(8, 2)) == bv<int64_t>(8, -1)`.
- **E7.** `makeRepresentable<int64_t>` — masks then sign-extends instead of clamping out-of-range values to `0`. Paired with `regressionModularAddWrapTest`: `modularAdd(bv<int64_t>(4, 7), bv(4, 1)) == bv<int64_t>(4, -8)`.
- **E8.** `operator-<int64_t>`, `modularNegate<int64_t>` — perform the negation in unsigned arithmetic to avoid `-INT64_MIN` signed-overflow undefined behavior. Paired with `regressionNegateMaxWidthTest` (value-equal at `-O0`; the falsifier is a `-fsanitize=undefined` build, which flags the overflow without this fix).
- **E9.** `stickyRightShift` — loop bound tightened to `i < width` and the whole-word case handled separately, so `1ULL << i` no longer hits shift-by-width undefined behavior at `i == 64`. Paired with `regressionSignExtendAtMaxWidthTest`: `bv<uint64_t>(64, 1ULL<<63).signExtendRightShift(bv(64, 64)) == bv(64, ~0ULL)`.
- **E10.** `simpleExecutable.cpp` — replaced the same-width int↔int `*((T *)&v)` reinterprets with `static_cast` (well-defined, bit-pattern preserving). Scope: library back-end only — the ~38 float↔int type-puns in `applications/executable.h` / `implementations.h` are the same strict-aliasing class but need `memcpy`/`bit_cast`, and are left for a separate change.

## Test plan

- [x] `make` builds cleanly
- [x] `./test --verbose` shows nine `regression*` tests as `PASS` (`isCatastrophicCancellation`, `ctorAtMaxWidth`, `maxValueAtMaxWidth`, `contractMasksHighBits`, `width1SignedEquality`, `signExtendRightShift`, `modularAddWrap`, `signExtendAtMaxWidth`, `negateAtMaxWidth`)
- [x] `./test` exits 0
- [x] `-fsanitize=undefined` build of `./test` runs clean (validates the E2/E3/E7/E8/E9 undefined-behavior fixes)
