### PR TITLE
Adapt sNaN handling in min()/max()

### DIFF
--- a/core/compare.h
+++ b/core/compare.h
@@ -183,9 +183,11 @@ namespace symfpu {
 			const unpackedFloat<t> &left,
 			const unpackedFloat<t> &right,
 			const typename t::prop &zeroCase) {
-    return ITE(left.getNaN() || ordering(format, left, right, zeroCase),
-	       right,
-	       left);
+    return ITE(left.getSignaling() || right.getSignaling(),
+               unpackedFloat<t>::makeNaN(format),
+               ITE(left.getNaN() || ordering(format, left, right, zeroCase),
+                   right,
+                   left));
   }
 
   // Note that IEEE-754 says that min(+0,-0) = +/-0 and min(-0,+0) = +/- 0
@@ -195,9 +197,11 @@ namespace symfpu {
 			const unpackedFloat<t> &left,
 			const unpackedFloat<t> &right,
 			const typename t::prop &zeroCase) {
-    return ITE(right.getNaN() || ordering(format, left, right, zeroCase),
-	       left,
-	       right);
+    return ITE(left.getSignaling() || right.getSignaling(),
+               unpackedFloat<t>::makeNaN(format),
+               ITE(right.getNaN() || ordering(format, left, right, zeroCase),
+                   left,
+                   right));
   }
 
 

--- a/core/packing.h
+++ b/core/packing.h
@@ -61,6 +61,7 @@ namespace symfpu {
     prop zeroExponent(packedExponent.isAllZeros());
     prop onesExponent(packedExponent.isAllOnes());
     prop zeroSignificand(significandWithLeadingZero.isAllZeros()); // Shared with normaliseUp
+    prop quietBit(packedSignificand.extract(sigWidth - 1, sigWidth - 1).isAllOnes());
 
     // Identify the cases
     prop isZero(zeroExponent && zeroSignificand);
@@ -68,6 +69,7 @@ namespace symfpu {
     prop isNormal(!zeroExponent && !onesExponent);
     prop isInf(onesExponent && zeroSignificand);
     prop isNaN(onesExponent && !zeroSignificand);
+    prop isSNaN(isNaN && !quietBit);
 
     INVARIANT(isZero || isSubnormal || isNormal || isInf || isNaN);
 
@@ -75,7 +77,9 @@ namespace symfpu {
     
     // Splice together
     unpackedFloat<t> uf(ITE(isNaN,
-			    unpackedFloat<t>::makeNaN(format),
+			    ITE(isSNaN,
+			        unpackedFloat<t>::makeSNaN(format),
+			        unpackedFloat<t>::makeNaN(format)),
 			    ITE(isInf,
 				unpackedFloat<t>::makeInf(format, sign),
 				ITE(isZero,
@@ -149,7 +153,9 @@ namespace symfpu {
     
     ubv packedSig(ITE(hasFixedSignificand,
 		      ITE(uf.getNaN(),
-			  unpackedFloat<t>::nanPattern(packedSigWidth),
+			  ITE(uf.getSignaling(),
+			      ubv::one(packedSigWidth),
+			      unpackedFloat<t>::nanPattern(packedSigWidth)),
 			  ubv::zero(packedSigWidth)),
 		      ITE(inNormalRange,
 			  dropLeadingOne,

--- a/core/unpackedFloat.h
+++ b/core/unpackedFloat.h
@@ -48,6 +48,7 @@ namespace symfpu {
     // TODO : protect these again
   public :
     prop nan;
+    prop signaling;
     prop inf;
     prop zero;
 
@@ -60,10 +61,10 @@ namespace symfpu {
     // via the constructor an invalid unpacked float
 
     // A piecewise / literal constructor using fpclass
-    enum fpclass { FPCLASS_NAN, FPCLASS_INF, FPCLASS_ZERO, FPCLASS_NUMBER };
+    enum fpclass { FPCLASS_NAN, FPCLASS_SNAN, FPCLASS_INF, FPCLASS_ZERO, FPCLASS_NUMBER };
 
     unpackedFloat (const fpclass c, const prop &s, const sbv &exp, const ubv &signif) : 
-      nan(c == FPCLASS_NAN), inf(c == FPCLASS_INF), zero(c == FPCLASS_ZERO),
+      nan(c == FPCLASS_NAN || c == FPCLASS_SNAN), signaling(c == FPCLASS_SNAN), inf(c == FPCLASS_INF), zero(c == FPCLASS_ZERO),
       sign(s), exponent(exp), significand(signif)
       {}
 
@@ -73,10 +74,14 @@ namespace symfpu {
 
     // TODO : See above -- this should only be used by ite
   public :
-    unpackedFloat (const prop &iteNaN, const prop &iteInf, const prop &iteZero,
+    unpackedFloat (const prop &iteNaN, const prop &iteSignaling, const prop &iteInf, const prop &iteZero,
 		   const prop &iteSign, const sbv &iteExponent, const ubv &iteSignificand) :
-      nan(iteNaN), inf(iteInf), zero(iteZero),
+      nan(iteNaN), signaling(iteSignaling), inf(iteInf), zero(iteZero),
       sign(iteSign), exponent(iteExponent), significand(iteSignificand)
+      {}
+    unpackedFloat (const prop &iteNaN, const prop &iteInf, const prop &iteZero,
+       const prop &iteSign, const sbv &iteExponent, const ubv &iteSignificand) :
+      unpackedFloat(iteNaN, false, iteInf, iteZero, iteSign, iteExponent, iteSignificand)
       {}
   private :
 
@@ -97,18 +102,18 @@ namespace symfpu {
 
   public :
     unpackedFloat (const prop &s, const sbv &exp, const ubv &signif) : 
-      nan(false), inf(false), zero(false),
+      nan(false), signaling(false), inf(false), zero(false),
       sign(s), exponent(exp), significand(signif)
       {}
 
     unpackedFloat (const unpackedFloat<t> &old) :
-      nan(old.nan), inf(old.inf), zero(old.zero),
+      nan(old.nan), signaling(old.signaling), inf(old.inf), zero(old.zero),
       sign(old.sign), exponent(old.exponent), significand(old.significand)
       {}
 
     // Copy and over-write sign
     unpackedFloat (const unpackedFloat<t> &old, const prop &s) : 
-      nan(old.nan), inf(old.inf), zero(old.zero),
+      nan(old.nan), signaling(old.signaling), inf(old.inf), zero(old.zero),
       sign(ITE(old.nan, old.sign, s)), exponent(old.exponent), significand(old.significand)
       {}
 
@@ -117,7 +122,7 @@ namespace symfpu {
 
     template <class s>
     unpackedFloat (const unpackedFloat<s> &old) :
-      nan(old.nan), inf(old.inf), zero(old.zero),
+      nan(old.nan), signaling(old.signaling), inf(old.inf), zero(old.zero),
       sign(old.sign), exponent(old.exponent), significand(old.significand)
       {}
       
@@ -145,7 +150,12 @@ namespace symfpu {
       return unpackedFloat<t>(FPCLASS_NAN, false, defaultExponent(unpackedFloat<t>::exponentWidth(fmt)), defaultSignificand(unpackedFloat<t>::significandWidth(fmt)));
     }
 
+    static unpackedFloat<t> makeSNaN(const fpt &fmt) {
+      return unpackedFloat<t>(FPCLASS_SNAN, false, defaultExponent(unpackedFloat<t>::exponentWidth(fmt)), defaultSignificand(unpackedFloat<t>::significandWidth(fmt)));
+    }
+
     inline const prop & getNaN(void) const { return this->nan; }
+    inline const prop & getSignaling(void) const { return this->signaling; }
     inline const prop & getInf(void) const { return this->inf; }
     inline const prop & getZero(void) const { return this->zero; }
     inline const prop & getSign(void) const { return this->sign; }
@@ -298,6 +308,7 @@ namespace symfpu {
 
     unpackedFloat<t> extend (const bwt expExtension, const bwt sigExtension) const {
       return unpackedFloat<t>(this->nan, 
+			      this->signaling,
 			      this->inf,
 			      this->zero,
 			      this->sign,
@@ -545,6 +556,7 @@ template <class t>
 			    const unpackedFloat<t> &l,					
 			    const unpackedFloat<t> &r) {				
     return unpackedFloat<t>(ITE(cond, l.nan, r.nan),
+			    ITE(cond, l.signaling, r.signaling),
 			    ITE(cond, l.inf, r.inf),
 			    ITE(cond, l.zero, r.zero),
 			    ITE(cond, l.sign, r.sign),


### PR DESCRIPTION
Pack/unpack the `quiet` bit and return qNaN from min()/max() if it is set on any input.

This fixes the discrepancy vs native code on amd64, ie.

```
$ ./test --max --min
Running test for max : .....................vector[1316176 -> (1660,0)] input1 = 0x7f800001, input2 = 0x0, computed = 0x0, real = 0x7fc00001
...
Running test for min : .....................vector[1316176 -> (1660,0)] input1 = 0x7f800001, input2 = 0x0, computed = 0x0, real = 0x7fc00001
```

also found by #5.