### PR TITLE
test: Fix generated C code for fma-FE_TONEAREST

### DIFF
--- a/applications/test.cpp
+++ b/applications/test.cpp
@@ -1186,7 +1186,7 @@ int main (int argc, char **argv) {
     {0,0,                "min", INST(binaryFunction, min),              "fminf(f,g)",  "(fp.min f g)"},
     {0,1,               "sqrt", INST(unaryRoundedFunction, sqrt),       "sqrtf(f)",  "(fp.sqrt rm f)"},
     {0,1,  "round_to_integral", INST(unaryRoundedFunction, rti),        "(fegetround()==FE_TONEAREST) ? rintf(f) : (fegetround()==FE_UPWARD) ? ceilf(f) : (fegetround()==FE_DOWNWARD) ? floorf(f) : truncf(f)",  "(fp.roundToIntegral rm f)"},
-    {0,1,                "fma", INST(ternaryRoundedFunction, fma),      "fmaf(f,g)",  "(fp.fma rm f g h)"},
+    {0,1,                "fma", INST(ternaryRoundedFunction, fma),      "fmaf(f,g,h)",  "(fp.fma rm f g h)"},
     {0,0,          "remainder", INST(binaryFunction, rem),              "remainderf(f,g)",  "(fp.remainder f g)"},
     {0,0,                 NULL, NULL, NULL, NULL,                           NULL,  NULL}
   };


### PR DESCRIPTION
Hi! I maintain a symfpu package for the GNU Guix distribution. As part of the packaging process, we attempt to always enable upstream's tests whenever available to ensure that the software works as expected with our packaged C toolchain and compiler optimizations.

For symfpu, I recently discovered the `applications/test.cpp` generator and attempted to enable the C-based tests on a small value range using `./test --allTests --end=5 --printC`. Compiling and running the tests worked well for all test cases expect the `fma-FE_TONEAREST` test case which failed to compile with:

```
./testC-fma-FE_TONEAREST-0.c: In function ‘int main()’:
./testC-fma-FE_TONEAREST-0.c:25:22: error: too few arguments to function ‘float fmaf(float, float, float)’
   25 | float computed = fmaf(f,g);
      |                  ~~~~^~~~~
In file included from /gnu/store/bl3qw29h2582k7hpifm90g508z838swc-gcc-14.3.0/include/c++/cmath:47,
                 from /gnu/store/bl3qw29h2582k7hpifm90g508z838swc-gcc-14.3.0/include/c++/math.h:36,
                 from ./testC-fma-FE_TONEAREST-0.c:4:
/gnu/store/m31vlvwm79m89fk3xk0z4h7snk61y510-glibc-2.41/include/bits/mathcalls.h:373:1: note: declared here
  373 | __MATHCALL (fma,, (_Mdouble_ __x, _Mdouble_ __y, _Mdouble_ __z));
      | ^~~~~~~~~~
```

I don't fully understand how this ever compiled since `fmaf(3)` has always required a third argument. However, looking at the generated test code it seems to me that passing `h` as the third argument was just overlooked? If i missed something obvious, then please let me know.

With this patch, the test case compiles and passes successfully. 