### PR TITLE
Fix an unrounded fast path in convertFloatToFloat when the exponent range narrows

### DIFF
--- a/applications/test.cpp
+++ b/applications/test.cpp
@@ -166,6 +166,8 @@ float getTestValue (uint64_t index) {
 // We are testing the 'simple executable' back-end
 typedef symfpu::simpleExecutable::traits traits;
 typedef traits::fpt fpt;
+typedef traits::ubv ubv;
+typedef symfpu::unpackedFloat<traits> uf;
 
 // We are also testing it only for single precision
 traits::fpt singlePrecisionFormatObject(8,24);
@@ -1124,6 +1126,76 @@ void ternaryRoundedFunctionPrintSMT (const int /*verbose*/, const uint64_t start
 
 
 
+/*** Format Conversion ***/
+
+// Everything above is single precision, checked against the hardware.  There
+// is no hardware reference for convertFloatToFloat, so check it against
+// itself : widening to a format that contains the source loses nothing, so
+// converting through one must agree with converting straight to the target.
+// Both sides are packed, which canonicalises NaN, so they compare directly.
+// The packed source value is the test vector number, so -s, -e and -t select
+// a range of it as usual.
+
+struct conversionStruct {
+  const fpt source;
+  const fpt wide;
+  const fpt target;
+};
+
+#define NUMBER_OF_CONVERSIONS 3
+void convertFormatTest (const int verbose, const uint64_t start, const uint64_t end) {
+  const conversionStruct conversions[NUMBER_OF_CONVERSIONS] = {
+    // The target's exponent range shrinks while the unpacked exponent width
+    // does not, which is where the promotion fast path was taken wrongly
+    { fpt(3,4), fpt(4,6), fpt(2,5) },
+    { fpt(3,6), fpt(4,8), fpt(2,7) },
+    // Control : here the unpacked width shrinks while the format's does not,
+    // the case that widening the extension guard as well would break
+    { fpt(2,6), fpt(3,8), fpt(2,4) }
+  };
+  const traits::rm modes[SYMFPU_NUMBER_OF_ROUNDING_MODES] =
+    { traits::RNE(), traits::RNA(), traits::RTP(), traits::RTN(), traits::RTZ() };
+
+  for (unsigned n = 0; n < NUMBER_OF_CONVERSIONS; ++n) {
+    const fpt &source = conversions[n].source;
+    const fpt &wide = conversions[n].wide;
+    const fpt &target = conversions[n].target;
+    uint64_t limit = 1ULL << source.packedWidth();
+
+    for (unsigned m = 0; m < SYMFPU_NUMBER_OF_ROUNDING_MODES; ++m) {
+      for (uint64_t i = start; i < end && i < limit; ++i) {
+	uf input(symfpu::unpack<traits>(source, ubv(source.packedWidth(), i)));
+
+	uint64_t direct = symfpu::pack<traits>(target,
+	  symfpu::convertFloatToFloat<traits>(source, target, modes[m], input)).contents();
+
+	uint64_t viaWide = symfpu::pack<traits>(target,
+	  symfpu::convertFloatToFloat<traits>(wide, target, modes[m],
+	    symfpu::convertFloatToFloat<traits>(source, wide, modes[m], input))).contents();
+
+	if (verbose || direct != viaWide) {
+	  fprintf(stdout, "\n(%u, %u) -> (%u, %u) input = 0x%x, computed = 0x%x, via (%u, %u) = 0x%x",
+		  (uint32_t)source.exponentWidth(), (uint32_t)source.significandWidth(),
+		  (uint32_t)target.exponentWidth(), (uint32_t)target.significandWidth(),
+		  (uint32_t)i, (uint32_t)direct,
+		  (uint32_t)wide.exponentWidth(), (uint32_t)wide.significandWidth(), (uint32_t)viaWide);
+	  fflush(stdout);
+	}
+      }
+    }
+    fprintf(stdout, ".");
+    fflush(stdout);
+  }
+
+  return;
+}
+
+void convertFormatPrint (const int, const uint64_t, const uint64_t, const char *, const char *, const char *) {
+  fprintf(stdout, "not supported for the conversion test");
+  return;
+}
+
+
 typedef void (*testFunction) (const int, const uint64_t, const uint64_t);
 typedef void (*printFunction) (const int, const uint64_t, const uint64_t, const char *, const char *, const char *);
 
@@ -1188,6 +1260,7 @@ int main (int argc, char **argv) {
     {0,1,  "round_to_integral", INST(unaryRoundedFunction, rti),        "(fegetround()==FE_TONEAREST) ? rintf(f) : (fegetround()==FE_UPWARD) ? ceilf(f) : (fegetround()==FE_DOWNWARD) ? floorf(f) : truncf(f)",  "(fp.roundToIntegral rm f)"},
     {0,1,                "fma", INST(ternaryRoundedFunction, fma),      "fmaf(f,g)",  "(fp.fma rm f g h)"},
     {0,0,          "remainder", INST(binaryFunction, rem),              "remainderf(f,g)",  "(fp.remainder f g)"},
+    {0,0,     "convertFormats", convertFormatTest, convertFormatPrint, convertFormatPrint, NULL, NULL},
     {0,0,                 NULL, NULL, NULL, NULL,                           NULL,  NULL}
   };
 
@@ -1248,6 +1321,7 @@ int main (int argc, char **argv) {
     {             "rti",        no_argument,               &(tests[21].enable),  1 },
     {             "fma",        no_argument,               &(tests[22].enable),  1 },
     {       "remainder",        no_argument,               &(tests[23].enable),  1 },
+    {  "convertFormats",        no_argument,               &(tests[24].enable),  1 },
     {             "rne",        no_argument,    &(roundingModeTests[0].enable),  1 },
     {             "rtp",        no_argument,    &(roundingModeTests[1].enable),  1 },
     {             "rtn",        no_argument,    &(roundingModeTests[2].enable),  1 },

--- a/core/convert.h
+++ b/core/convert.h
@@ -32,10 +32,20 @@ unpackedFloat<t> convertFloatToFloat (const typename t::fpt &sourceFormat,
   //typedef typename t::sbv sbv;
 
   // increased includes equality
-  bool exponentIncreased = unpackedFloat<t>::exponentWidth(sourceFormat) <= unpackedFloat<t>::exponentWidth(targetFormat);
+
+  // The width expExtension measures.  It can shrink where the format's
+  // exponent does not, (2,6) -> (2,4) goes 4 -> 3, so it is what keeps that
+  // subtraction non-negative
+  bool unpackedExponentIncreased = unpackedFloat<t>::exponentWidth(sourceFormat) <= unpackedFloat<t>::exponentWidth(targetFormat);
+
+  // Whether the target can represent every source exponent, which is what the
+  // fast path needs.  A narrowing target can still have an equal or larger
+  // unpacked width, so testing that one takes the fast path for a narrowing
+  bool exponentIncreased = sourceFormat.exponentWidth() <= targetFormat.exponentWidth();
+
   bool significandIncreased = unpackedFloat<t>::significandWidth(sourceFormat) <= unpackedFloat<t>::significandWidth(targetFormat);
 
-  bwt expExtension = (exponentIncreased) ? unpackedFloat<t>::exponentWidth(targetFormat) - unpackedFloat<t>::exponentWidth(sourceFormat) : 0;
+  bwt expExtension = (unpackedExponentIncreased) ? unpackedFloat<t>::exponentWidth(targetFormat) - unpackedFloat<t>::exponentWidth(sourceFormat) : 0;
 
   // Format sizes are literal so it is safe to branch on them
   if (exponentIncreased && significandIncreased) {


### PR DESCRIPTION
A soundness bug in `convertFloatToFloat`. Independent of #14 & #15.

`convertFloatToFloat` chooses between rounding and an unrounded "fast path strict promotion" on whether the exponent width increases, and reads the wrong width for that question:

```c++
bool exponentIncreased = unpackedFloat<t>::exponentWidth(sourceFormat) <= unpackedFloat<t>::exponentWidth(targetFormat);
```

`significandWidth(format)` is the format's own `sb`, but `exponentWidth(format)` is the internal unpacked width, and the two come apart. A target whose format exponent range is *smaller* can still have an equal or larger unpacked width — source `(3, 4)` and target `(2, 5)` both unpack to 4 — so a narrowing is taken for a promotion, and the value is returned unrounded and unclamped. Overflowing values never saturate to infinity; they come back as NaNs, subnormals or zeros. Ties never round, because the rounder is skipped outright.

With assertions on this shows up as the fast path's own `POSTCONDITION(extended.valid(targetFormat))`. With them off it silently returns values outside the target format, which for anything using SymFPU to bit-blast is a wrong answer rather than a crash.

The interchange formats never reach it. Narrowing between Float16, Float32, Float64 and Float128 always shrinks the unpacked width too, so those take the rounding path; it needs a format outside that set on one side.

The fast path now tests the format's exponent width, which is the condition it actually needs. `expExtension` keeps the unpacked comparison, and the two have to stay separate: the unpacked width can shrink where the format's does not — `(2, 6) -> (2, 4)` goes 4 to 3 — so widening that guard as well underflows an unsigned subtraction and breaks conversions that were previously correct.